### PR TITLE
Add VS Code dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,40 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/dotnet
+{
+	"name": "C# (.NET)",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/dotnet:1-8.0-bookworm",
+	"features": {
+		"ghcr.io/stuartleeks/dev-container-features/shell-history:0": {},
+		"ghcr.io/devcontainers/features/dotnet": {
+			"version": "7.0"
+		}
+	},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-dotnettools.csdevkit"
+			]
+		}
+	}
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [5000, 5001],
+	// "portsAttributes": {
+	//		"5001": {
+	//			"protocol": "https"
+	//		}
+	// }
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "dotnet restore",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -462,3 +462,5 @@ $RECYCLE.BIN/
 ### configuration of Omnisharp for script intelisens 
 ###
 !starter.rsp
+
+.mono/

--- a/setup-example.sh
+++ b/setup-example.sh
@@ -1,0 +1,7 @@
+#! /bin/bash
+set -e
+
+dotnet build
+dotnet pack
+cd ./example
+dotnet tool restore


### PR DESCRIPTION
- Add dev container (based on .NET 8 but also installs .NET 7 as some projects still require that)
- Add bash script version of `setup-example.cmd` for setting up example project in dev container
- Ignore `.mono\*` files that get added when building
